### PR TITLE
Chore/add type module to package json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @902seanryan @aberkie @deycorinne
+* @pbs/pbs-kids-web-squad

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The iframe controller for interacting with SpringRoll applications",
   "main": "./dist/index.js",
   "license": "MIT",
+  "type": "module",
   "typings": "typings/index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
As we decide the fate of SpringRoll Container (who maintains it) and as we are building out the web player, we made this fork to experiment with. This PR updates the code owners for the fork, and adds type: module to the package.json to try and troubleshoot an issue we're having using imports from the Container.