### PR TITLE
require manual unpause when app is refocused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update PausePlugin to require manual unpause when the application window regains focus. [Ticket](https://www.pivotaltracker.com/story/show/188461849)
+- REDESIGN UPDATE - Update PausePlugin to require manual unpause when the application window regains focus. [Ticket](https://www.pivotaltracker.com/story/show/188461849)
 
 ## [2.5.2] - 2024-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update PausePlugin to require manual unpause when the application window regains focus. [Ticket](https://www.pivotaltracker.com/story/show/188422978)
+- Update PausePlugin to require manual unpause when the application window regains focus. [Ticket](https://www.pivotaltracker.com/story/show/188461849)
 
 ## [2.5.2] - 2024-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.3] - 2025-01-03
+## [3.0.0] - 2025-01-03
+
+This is the start of the websquad's fork of https://github.com/springroll/SpringRollContainer to be used in the pbskids redesign (project name "Puma").
 
 ### Changed
 
-- REDESIGN UPDATE - Update PausePlugin to require manual unpause when the application window regains focus. [Ticket](https://www.pivotaltracker.com/story/show/188461849)
+- Update PausePlugin to require manual unpause when the application window regains focus. [Ticket](https://www.pivotaltracker.com/story/show/188461849)
 
 ## [2.5.2] - 2024-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.3] - 2025-01-03
+
+### Changed
+
+- Update PausePlugin to require manual unpause when the application window regains focus. [Ticket](https://www.pivotaltracker.com/story/show/188422978)
+
 ## [2.5.2] - 2024-06-18
 
 ### Fixed

--- a/src/plugins/PausePlugin.js
+++ b/src/plugins/PausePlugin.js
@@ -139,10 +139,6 @@ export class PausePlugin extends ButtonPlugin {
     if (!this.manageOwnVisibility) {
       return;
     }
-    // Unfocus on the iframe
-    if (this._keepFocus) {
-      this.blurApp();
-    }
 
     // we only need one delayed call, at the end of any
     // sequence of rapidly-fired blur/focus events
@@ -157,13 +153,10 @@ export class PausePlugin extends ButtonPlugin {
     this._focusTimer = setTimeout(
       function () {
         this._focusTimer = null;
-        // A manual pause cannot be overriden by focus events.
-        // User must click the resume button.
-        if (this._isManualPause) {
-          return;
-        }
 
-        this.pause = Boolean(this._containerBlurred && this._appBlurred);
+        if (this._appBlurred && this._containerBlurred) {
+          this.pause = true;
+        }
 
         // Focus on the content window when blurring the app
         // but selecting the container


### PR DESCRIPTION
Instead of toggling pause state on application focus, just set pause to true when focus is lost, requiring a manual unpause via pause buttons.